### PR TITLE
Convert the site to Jekyll.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+_site
+.sass-cache
+.jekyll-cache
+.jekyll-metadata
+vendor
+Gemfile.lock

--- a/404.html
+++ b/404.html
@@ -1,0 +1,25 @@
+---
+permalink: /404.html
+layout: default
+---
+
+<style type="text/css" media="screen">
+  .container {
+    margin: 10px auto;
+    max-width: 600px;
+    text-align: center;
+  }
+  h1 {
+    margin: 30px 0;
+    font-size: 4em;
+    line-height: 1;
+    letter-spacing: -1px;
+  }
+</style>
+
+<div class="container">
+  <h1>404</h1>
+
+  <p><strong>Page not found :(</strong></p>
+  <p>The requested page could not be found.</p>
+</div>

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,33 @@
+source "https://rubygems.org"
+# Hello! This is where you manage which Jekyll version is used to run.
+# When you want to use a different version, change it below, save the
+# file and run `bundle install`. Run Jekyll with `bundle exec`, like so:
+#
+#     bundle exec jekyll serve
+#
+# This will help ensure the proper Jekyll version is running.
+# Happy Jekylling!
+# gem "jekyll", "~> 4.3.4"
+# This is the default theme for new Jekyll sites. You may change this to anything you like.
+gem "minima", "~> 2.5"
+# If you want to use GitHub Pages, remove the "gem "jekyll"" above and
+# uncomment the line below. To upgrade, run `bundle update github-pages`.
+gem "github-pages", "~> 232", group: :jekyll_plugins
+# If you have any plugins, put them here!
+group :jekyll_plugins do
+  gem "jekyll-feed", "~> 0.12"
+end
+
+# Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem
+# and associated library.
+platforms :mingw, :x64_mingw, :mswin, :jruby do
+  gem "tzinfo", ">= 1", "< 3"
+  gem "tzinfo-data"
+end
+
+# Performance-booster for watching directories on Windows
+gem "wdm", "~> 0.1", :platforms => [:mingw, :x64_mingw, :mswin]
+
+# Lock `http_parser.rb` gem to `v0.6.x` on JRuby builds since newer versions of the gem
+# do not have a Java counterpart.
+gem "http_parser.rb", "~> 0.6.0", :platforms => [:jruby]

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,12 @@
+domain: 5bfp.org
+url: https://5bfp.org
+title: Five Borough Fedi Project
+email: help@masto.nyc
+description: >-
+ Five Borough Fedi Project is the nonprofit that owns and
+ operates Masto.NYC, a free social media service for the people
+ and organizations of New York City.
+# Build settings
+theme: minima
+plugins:
+  - jekyll-feed

--- a/give.md
+++ b/give.md
@@ -1,0 +1,36 @@
+---
+# Feel free to add content and custom Front Matter to this file.
+# To modify the layout, see https://jekyllrb.com/docs/themes/#overriding-theme-defaults
+
+layout: page
+title: Support Masto.NYC with a donation
+---
+Masto.NYC is a free public service funded by its users. If you love Masto.NYC and you can afford to help support our operations, then we would be so grateful for a gift of any size using one of the methods listed below.
+
+All donations help us pay for the various services that Masto.NYC needs to stay online and stable. A public Mastodon server isn't cheap to run, and our costs only rise as our usage grows. We do rely on the generosity of our user community to make sure that we can continue to deliver Masto.NYC as a fast, reliable service.
+
+Donations by U.S. citizens are tax-deductible
+in most cases!
+
+### Make a donation online
+
+To make a one-time or repeating donation using a credit card, Apple Pay, or bank withdrawal, [visit our donation page at Give Lively](http://masto.nyc/give).
+
+While we are grateful for gifts of any size, we especially appreciate monthly donations. They do a lot to help us plan how much money we can spend on server costs and other expenses month-to-month. 
+
+### Use corporate matching
+
+If your employer supports a donation-matching program for charitable gifts, or even provides an annual stipend expressly for donations, then you might be able to use this program to donate to 5BFP and Masto.NYC. Check your corporate donation program's charity list for "Five Borough Fedi Project".
+
+### Mail us a check
+
+You can also just mail us an old-fashioned on-paper check, drawn on a U.S. bank:
+
+Five Borough Fedi Project<br/>
+93 4th Ave.<br/>
+PO Box 1323<br/>
+New York, NY 10003
+
+Make the check payable to Five Borough Fedi Project, Inc.
+
+We don't check our paper mailbox regularly, so if you do mail us a check, please do email <help@masto.nyc> as well, to let us know that we should expect your gift!

--- a/index.md
+++ b/index.md
@@ -1,3 +1,10 @@
+---
+# Feel free to add content and custom Front Matter to this file.
+# To modify the layout, see https://jekyllrb.com/docs/themes/#overriding-theme-defaults
+
+layout: home
+---
+
 <img src="images/statue.png" style="margin:10px; float:right; max-width: 50%" alt="A cartoon mastodon dressed like the Statue of Liberty and enjoying a slice of pizza." />
 
 This is the homepage of Five Borough Fedi Project (5BFP), the New York-based nonprofit corporation that operates the [Masto.NYC Mastodon server](https://masto.nyc).
@@ -10,36 +17,6 @@ social media service in 2024. This is our mission statement:
 > The Five Borough Fedi Project operates free, federated, non-commercial social media services for the residents, workers, and organizations of the New York metropolitan area.
 
 As a non-profit corporation organized in New York State, 5BFP owns and operates Masto.NYC as an independent, volunteer-run legal entity. The organization's 501(c)(3) charitable status lets us accept tax-deductible donations from the public. All this helps us keep Masto.NYC online, stable, and funded for the long term.
-
-## Support Masto.NYC with a donation
-
-Masto.NYC is a free public service funded by its users. If you love Masto.NYC and you can afford to help support our operations, then we would be so grateful for a gift of any size using one of the methods listed below.
-
-All donations help us pay for the various services that Masto.NYC needs to stay online and stable. A public Mastodon server isn't cheap to run, and our costs only rise as our usage grows. We do rely on the generosity of our user community to make sure that we can continue to deliver Masto.NYC as a fast, reliable service.
-
-Donations by U.S. citizens are tax-deductible
-in most cases!
-
-### Make a donation online
-
-To make a one-time or repeating donation using a credit card, Apple Pay, or bank withdrawal, [visit our donation page at Give Lively](https://secure.givelively.org/donate/99-2048115).
-
-While we are grateful for gifts of any size, we especially appreciate monthly donations. They do a lot to help us plan how much money we can spend on server costs and other expenses month-to-month. 
-
-### Use corporate matching
-
-If your employer supports a donation-matching program for charitable gifts, or even provides an annual stipend expressly for donations, then you might be able to use this program to donate to 5BFP and Masto.NYC. Check your corporate donation program's charity list for "Five Borough Fedi Project".
-
-### Mail us a check
-
-You can also just mail us an old-fashioned on-paper check, drawn on a U.S. bank:
-
-Five Borough Fedi Project<br/>
-93 4th Ave.<br/>
-PO Box 1323<br/>
-New York, NY 10003
-
-Make the check payable to Five Borough Fedi Project, Inc. We don't receive a lot of paper mail, so you can also email <help@masto.nyc> to let us know that we should expect your gift!
 
 ## Contact us
 


### PR DESCRIPTION
This PR converts the site to using Jekyll, what with its native Github Pages support.

To test this locally, see https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/testing-your-github-pages-site-locally-with-jekyll.

This PR also splits the current single page into two separate pages, largely as a proof of concept, putting the donation information on its own page. It makes no further content changes.