### PR TITLE
Override the theme navbar with our own:

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,0 +1,27 @@
+<header class="site-header" role="banner">
+
+  <div class="wrapper">
+    {%- assign default_paths = site.pages | map: "path" -%}
+    {%- assign page_paths = site.header_pages | default: default_paths -%}
+    <a class="site-title" rel="author" href="{{ "/" | relative_url }}">5BFP</a>
+
+    {%- if page_paths -%}
+      <nav class="site-nav">
+        <input type="checkbox" id="nav-trigger" class="nav-trigger" />
+        <label for="nav-trigger">
+          <span class="menu-icon">
+            <svg viewBox="0 0 18 15" width="18px" height="15px">
+              <path d="M18,1.484c0,0.82-0.665,1.484-1.484,1.484H1.484C0.665,2.969,0,2.304,0,1.484l0,0C0,0.665,0.665,0,1.484,0 h15.032C17.335,0,18,0.665,18,1.484L18,1.484z M18,7.516C18,8.335,17.335,9,16.516,9H1.484C0.665,9,0,8.335,0,7.516l0,0 c0-0.82,0.665-1.484,1.484-1.484h15.032C17.335,6.031,18,6.696,18,7.516L18,7.516z M18,13.516C18,14.335,17.335,15,16.516,15H1.484 C0.665,15,0,14.335,0,13.516l0,0c0-0.82,0.665-1.483,1.484-1.483h15.032C17.335,12.031,18,12.695,18,13.516L18,13.516z"/>
+            </svg>
+          </span>
+        </label>
+
+        <div class="trigger">
+        <a class="page-link" href="/give.html">Support Masto.NYC</a>
+        <a class="page-link" href="/policies.html">Policies and resources</a>
+        <a class="page-link" href="/reasons.html">Reasons to join Masto.NYC</a>
+        </div>
+      </nav>
+    {%- endif -%}
+  </div>
+</header>

--- a/index.md
+++ b/index.md
@@ -1,5 +1,6 @@
 ---
 layout: home
+title: Five Borough Fedi Project
 ---
 
 <img src="images/statue.png" style="margin:10px; float:right; max-width: 50%" alt="A cartoon mastodon dressed like the Statue of Liberty and enjoying a slice of pizza." />


### PR DESCRIPTION
* Display the org's abbreviation instead of its full, long name in the nav bar.
* Link only to certain pages, using shorter titles. The welcome page becomes unlisted.

Fixes #6.